### PR TITLE
Remove 4.01 Travis build (jbuilder/travis-opam breakage)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.01
   - OCAML_VERSION=4.02
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04


### PR DESCRIPTION
`travis-opam` now uses jbuilder, so it no longer works with OCaml 4.01.  See https://github.com/ocaml/ocaml-ci-scripts/pull/180.