### PR TITLE
Add 4.09 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
   - OCAML_VERSION=4.06
   - OCAML_VERSION=4.07
   - OCAML_VERSION=4.08
+  - OCAML_VERSION=4.09
 os:
   - linux


### PR DESCRIPTION
Also, maybe it makes sense to deprecate a few versions? E.g. up to 4.05, since most distributions now provide at least 4.05:

[![Packaging status](https://repology.org/badge/vertical-allrepos/ocaml.svg)](https://repology.org/project/ocaml/versions)